### PR TITLE
Speed up things with optimized gzip compression

### DIFF
--- a/wordpress/nginx.conf
+++ b/wordpress/nginx.conf
@@ -11,6 +11,24 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
     gzip on;
+    gzip_comp_level 5;
+    gzip_min_length 256;
+    gzip_types
+        application/atom+xml
+        application/javascript
+        application/json
+        application/rss+xml
+        application/vnd.ms-fontobject
+        application/x-font-ttf
+        application/x-web-app-manifest+json
+        application/xhtml+xml
+        application/xml
+        font/opentype
+        image/svg+xml
+        image/x-icon
+        text/css
+        text/plain
+        text/x-component;    
     gzip_disable "msie6";
 
     server {


### PR DESCRIPTION
Hey,

the following nginx changes let us save 50 percent of the traffic made by an default wordpress installation.

What do you think?

Have a nice day! 🙂
- thueske